### PR TITLE
Make tracker home menu label descriptive and conditional

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: '' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: 'monthly'

--- a/src/electron/constants.ts
+++ b/src/electron/constants.ts
@@ -51,6 +51,12 @@ export const MENU_IDS = {
   },
 };
 
+// Tracker Home Text
+export const TRACKER_HOME_MENU_TEXT = {
+  returnToPackSelection: 'Return to Pack Selection',
+  refreshPacks: 'Refresh Packs',
+};
+
 // Window size
 export const DEFAULT_WINDOW_SIZE = {
   width: 800,

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -6,7 +6,7 @@ import {
   TrackerState,
 } from '../shared/types/config.types.js';
 import { loadTrackerState, saveTrackerState } from './config.js';
-import { IPC_IDS, MENU_IDS } from './constants.js';
+import { IPC_IDS, MENU_IDS, TRACKER_HOME_MENU_TEXT } from './constants.js';
 import { getImage } from './images.js';
 import { menu } from './menu.js';
 import {
@@ -101,10 +101,17 @@ export function runIpcHandlers() {
   });
 
   ipcMain.handle(IPC_IDS.setTrackerMenuItems, (_, enabled: boolean) => {
+    const trackerHomeMenuItem = menu.getMenuItemById(MENU_IDS.file.trackerHome);
     const exportMenuItem = menu.getMenuItemById(MENU_IDS.file.exportState);
     const resetTrackerMenuItem = menu.getMenuItemById(
       MENU_IDS.file.resetTracker
     );
+
+    if (trackerHomeMenuItem) {
+      trackerHomeMenuItem.label = enabled
+        ? TRACKER_HOME_MENU_TEXT.returnToPackSelection
+        : TRACKER_HOME_MENU_TEXT.refreshPacks;
+    }
 
     if (exportMenuItem) {
       exportMenuItem.enabled = enabled;

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -6,7 +6,11 @@ import {
   shell,
 } from 'electron';
 import { ThemeType } from '../shared/types/base.types.js';
-import { MENU_IDS, USER_DATA_DIR } from './constants.js';
+import {
+  MENU_IDS,
+  TRACKER_HOME_MENU_TEXT,
+  USER_DATA_DIR,
+} from './constants.js';
 import {
   exportTrackerState,
   importTrackerState,
@@ -47,7 +51,7 @@ const template: MenuItemConstructorOptions[] = [
     submenu: [
       {
         id: MENU_IDS.file.trackerHome,
-        label: 'Home',
+        label: TRACKER_HOME_MENU_TEXT.refreshPacks,
         click: () => trackerHome(),
       },
       {
@@ -103,7 +107,7 @@ const template: MenuItemConstructorOptions[] = [
       },
       {
         id: MENU_IDS.toggles.resetSizeOnPackOpen,
-        label: 'Use Pack\'s Default Window Size on Load',
+        label: "Use Pack's Default Window Size on Load",
         type: 'checkbox',
         checked: false,
       },

--- a/src/ui/components/atom-combobox.tsx
+++ b/src/ui/components/atom-combobox.tsx
@@ -36,7 +36,7 @@ export function AtomCombobox({ atom, options, placeholder, emptyStr }: Props) {
         setValue('');
       }
     }
-  // oxlint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Sync the value atom with the inputValue state


### PR DESCRIPTION
- "Tracker Home" menu label is now the following:
  - "Refresh Packs" when at the pack selection/home page
  - "Return to Pack Selection" when viewing a tracker pack