### PR TITLE
Fix pack details error causing two error boxes to appear

### DIFF
--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -36,7 +36,7 @@ export function runIpcHandlers() {
       resetWindowSize(packId);
     }
 
-    return getPackDetails(packId);
+    return packDetails;
   });
 
   // get image


### PR DESCRIPTION
- I was accidentally calling `getPackDetails()` again in the ipc handler. This has been fixed so the variable is returned instead.
- This fixes #103.