### PR TITLE
Refactor all `dialog.showErrorBox()` calls to `dialog.showMessageBox()`

### DIFF
--- a/src/electron/config.ts
+++ b/src/electron/config.ts
@@ -1,4 +1,3 @@
-import { dialog } from 'electron';
 import fs from 'fs';
 import { dirname } from 'path';
 import {
@@ -13,7 +12,7 @@ import {
   USER_TRACKER_SAVES_PATH,
 } from './constants.js';
 import { readAndParseJsonFile, readJsonFile, writeJsonFile } from './io.js';
-import { getErrorMsg } from './util.js';
+import { getErrorMsg, showDialog } from './util.js';
 
 export function readConfigFile(path: string = CONFIG_PATH) {
   return readAndParseJsonFile(path, ConfigSchema);
@@ -52,7 +51,11 @@ export function saveTrackerState(
   fs.mkdir(dir, { recursive: true }, (err) => {
     if (err) {
       if (showErrorBox) {
-        dialog.showErrorBox('Failed to Create Directory', getErrorMsg(err));
+        showDialog({
+          type: 'error',
+          title: 'Failed to Create Directory',
+          message: getErrorMsg(err),
+        });
       }
       return console.error(
         'saveTrackerState(): Error creating save directory:',
@@ -64,10 +67,11 @@ export function saveTrackerState(
       fs.writeFile(path, json, (err) => {
         if (err) {
           if (showErrorBox) {
-            dialog.showErrorBox(
-              'Failed to Save Tracker State',
-              `Failed to save ${path}: ${getErrorMsg(err)}`
-            );
+            showDialog({
+              type: 'error',
+              title: 'Failed to Save Tracker State',
+              message: `Failed to save ${path}: ${getErrorMsg(err)}`,
+            });
           }
           console.error(
             'saveTrackerState(): Error writing json file:',

--- a/src/electron/config.ts
+++ b/src/electron/config.ts
@@ -50,6 +50,10 @@ export function saveTrackerState(
   const dir = dirname(path);
   fs.mkdir(dir, { recursive: true }, (err) => {
     if (err) {
+      console.error(
+        'saveTrackerState(): Error creating save directory:',
+        getErrorMsg(err)
+      );
       if (showErrorBox) {
         showDialog({
           type: 'error',
@@ -57,15 +61,18 @@ export function saveTrackerState(
           message: getErrorMsg(err),
         });
       }
-      return console.error(
-        'saveTrackerState(): Error creating save directory:',
-        getErrorMsg(err)
-      );
+
+      return;
     } else {
       // Handle writing file
       const json = JSON.stringify(state, null, 2);
       fs.writeFile(path, json, (err) => {
         if (err) {
+          console.error(
+            'saveTrackerState(): Error writing json file:',
+            path,
+            getErrorMsg(err)
+          );
           if (showErrorBox) {
             showDialog({
               type: 'error',
@@ -73,11 +80,6 @@ export function saveTrackerState(
               message: `Failed to save ${path}: ${getErrorMsg(err)}`,
             });
           }
-          console.error(
-            'saveTrackerState(): Error writing json file:',
-            path,
-            getErrorMsg(err)
-          );
         }
       });
     }

--- a/src/electron/io.ts
+++ b/src/electron/io.ts
@@ -1,7 +1,6 @@
-import { dialog } from 'electron';
 import fs from 'fs';
 import z from 'zod';
-import { getErrorMsg } from './util.js';
+import { getErrorMsg, showDialog } from './util.js';
 
 export function readJsonFile(path: string) {
   try {
@@ -23,10 +22,11 @@ export function readJsonFile(path: string) {
 export function writeJsonFile(path: string, json: string) {
   fs.writeFile(path, json, (err) => {
     if (err) {
-      dialog.showErrorBox(
-        'Error writing json file',
-        `An error occurred writing ${path}: ${getErrorMsg(err)}`
-      );
+      showDialog({
+        type: 'error',
+        title: 'Error writing json file',
+        message: `An error occurred writing ${path}: ${getErrorMsg(err)}`,
+      });
       console.error(
         'writeJsonFile(): Error writing json file:',
         path,

--- a/src/electron/io.ts
+++ b/src/electron/io.ts
@@ -22,16 +22,16 @@ export function readJsonFile(path: string) {
 export function writeJsonFile(path: string, json: string) {
   fs.writeFile(path, json, (err) => {
     if (err) {
-      showDialog({
-        type: 'error',
-        title: 'Error writing json file',
-        message: `An error occurred writing ${path}: ${getErrorMsg(err)}`,
-      });
       console.error(
         'writeJsonFile(): Error writing json file:',
         path,
         getErrorMsg(err)
       );
+      showDialog({
+        type: 'error',
+        title: 'Error writing json file',
+        message: `An error occurred writing ${path}: ${getErrorMsg(err)}`,
+      });
     }
   });
 }

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -15,7 +15,7 @@ import {
   getBasicPack,
   getPackDetails,
 } from './packs.js';
-import { getErrorMsg } from './util.js';
+import { getErrorMsg, showDialog } from './util.js';
 import { getMainWindow, resetWindowSize } from './window.js';
 
 export function runIpcHandlers() {
@@ -173,10 +173,13 @@ export function exportTrackerState() {
 
       // If no active pack is set, show error
       if (!pack) {
-        dialog.showErrorBox(
-          'Export Error',
-          `The application returned a nonexistent tracker pack with (pack ID: ${packId})`
-        );
+        const mainWindow = getMainWindow();
+        if (mainWindow) {
+          dialog.showMessageBox(mainWindow, {
+            title: 'Export Error',
+            message: `The application returned a nonexistent tracker pack with (pack ID: ${packId})`,
+          });
+        }
         console.error(
           'exportTrackerStateResponse(): Got a null pack from packId',
           packId
@@ -231,10 +234,11 @@ export function importTrackerState() {
         const state = loadTrackerState(value.filePaths[0]);
 
         if (!state.success) {
-          dialog.showErrorBox(
-            'Import State Error',
-            'The tracker state is invalid and cannot be imported.'
-          );
+          showDialog({
+            type: 'error',
+            title: 'Import State Error',
+            message: 'The tracker state is invalid and cannot be imported.',
+          });
           console.error(
             'importTrackerState(): Tracker state is invalid:',
             state.error

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -234,15 +234,16 @@ export function importTrackerState() {
         const state = loadTrackerState(value.filePaths[0]);
 
         if (!state.success) {
+          console.error(
+            'importTrackerState(): Tracker state is invalid:',
+            state.error
+          );
           showDialog({
             type: 'error',
             title: 'Import State Error',
             message: 'The tracker state is invalid and cannot be imported.',
           });
-          console.error(
-            'importTrackerState(): Tracker state is invalid:',
-            state.error
-          );
+
           return;
         }
 
@@ -250,17 +251,19 @@ export function importTrackerState() {
         const pack = getBasicPack(state.data.pack.id);
 
         if (pack?.version !== state.data.pack.version) {
-          dialog.showErrorBox(
-            pack ? 'Version Mismatch' : 'Missing Pack',
-            pack
-              ? `The version of the tracker state (${state.data.pack.version}) does not match the version of the pack (${pack.version}). Aborting.`
-              : 'Could not find the pack for this import. Is it installed?'
-          );
           console.error(
             'importTrackerState(): version mismatch or missing pack:',
             state.data.pack.version,
             pack ? pack.version : null
           );
+          showDialog({
+            type: 'error',
+            title: pack ? 'Version Mismatch' : 'Missing Pack',
+            message: pack
+              ? `The version of the tracker state (${state.data.pack.version}) does not match the version of the pack (${pack.version}). Aborting.`
+              : 'Could not find the pack for this import. Is it installed?',
+          });
+
           return;
         }
 
@@ -268,13 +271,14 @@ export function importTrackerState() {
       }
     })
     .catch((err: any) => {
-      dialog.showErrorBox(
-        'Import Error',
-        `Tracker state failed to import. ${getErrorMsg(err)}`
-      );
       console.error(
         'importTrackerState(): Error loading tracker state:',
         getErrorMsg(err)
       );
+      showDialog({
+        type: 'error',
+        title: 'Import Error',
+        message: `Tracker state failed to import. ${getErrorMsg(err)}`,
+      });
     });
 }

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -173,17 +173,15 @@ export function exportTrackerState() {
 
       // If no active pack is set, show error
       if (!pack) {
-        const mainWindow = getMainWindow();
-        if (mainWindow) {
-          dialog.showMessageBox(mainWindow, {
-            title: 'Export Error',
-            message: `The application returned a nonexistent tracker pack with (pack ID: ${packId})`,
-          });
-        }
         console.error(
           'exportTrackerStateResponse(): Got a null pack from packId',
           packId
         );
+        showDialog({
+          type: 'error',
+          title: 'Export Error',
+          message: `The application returned a nonexistent tracker pack with (pack ID: ${packId})`,
+        });
 
         return;
       }

--- a/src/electron/packs.ts
+++ b/src/electron/packs.ts
@@ -111,7 +111,7 @@ export function buildTrackerAutosavePath(pack: BasicPack) {
   );
 }
 
-export function installPack(srcFilePath: string) {
+export async function installPack(srcFilePath: string) {
   const mainWindow = getMainWindow();
   const packFileName = basename(srcFilePath);
   const destination = path.join(USER_PACKS_PATH, packFileName);
@@ -123,7 +123,7 @@ export function installPack(srcFilePath: string) {
 
   // Confirm if the pack file already exists
   if (fs.existsSync(destination)) {
-    const confirmButtonId = dialog.showMessageBoxSync(mainWindow, {
+    const confirmButtonId = await showDialog({
       title: 'Pack Exists',
       message: 'A pack with this file name exists. Overwrite?',
       type: 'warning',
@@ -132,7 +132,10 @@ export function installPack(srcFilePath: string) {
     });
 
     // If the user cancels, just return immediately/abort
-    if (confirmButtonId === confirmOverwriteCancelId) {
+    if (
+      !confirmButtonId ||
+      confirmButtonId.response === confirmOverwriteCancelId
+    ) {
       return;
     }
   }
@@ -140,7 +143,7 @@ export function installPack(srcFilePath: string) {
   fsPromises
     .cp(srcFilePath, destination)
     .then(() => {
-      dialog.showMessageBox(mainWindow, {
+      showDialog({
         title: 'Success',
         message: `${packFileName} installed successfully.`,
         type: 'info',

--- a/src/electron/packs.ts
+++ b/src/electron/packs.ts
@@ -17,7 +17,7 @@ import {
 import { getImage } from './images.js';
 import { readDir } from './io.js';
 import { buildPackDetails } from './pack-builder.js';
-import { getErrorMsg } from './util.js';
+import { getErrorMsg, showDialog } from './util.js';
 import { getMainWindow } from './window.js';
 
 let packs: BasicPack[];
@@ -90,10 +90,11 @@ export function getPackDetails(packId: string) {
 
   if (!match) {
     console.error('getPackDetails(): No matching pack for packId', packId);
-    dialog.showErrorBox(
-      'Error Loading Pack',
-      'The application could not find the specified pack.'
-    );
+    showDialog({
+      type: 'error',
+      title: 'Error Loading Pack',
+      message: 'The application could not find the specified pack.',
+    });
     return null;
   }
 
@@ -150,13 +151,14 @@ export function installPack(srcFilePath: string) {
       mainWindow?.webContents.send(IPC_IDS.trackerHome);
     })
     .catch((err: any) => {
-      dialog.showErrorBox(
-        'Error Installing',
-        `An error occurred installing ${packFileName}: ${getErrorMsg(err)}`
-      );
       console.error(
         `An error occurred installing ${packFileName}: ${getErrorMsg(err)}`
       );
+      showDialog({
+        type: 'error',
+        title: 'Error Installing',
+        message: `An error occurred installing ${packFileName}: ${getErrorMsg(err)}`,
+      });
     });
 }
 
@@ -180,11 +182,12 @@ export function installPackDialog() {
         const packTrackerJson = getPackTrackerJson(filePath);
 
         if (!packTrackerJson) {
-          dialog.showErrorBox(
-            'Invalid Pack',
-            `${packFileName} is invalid and cannot be installed.`
-          );
           console.error('installPackDialog(): packTrackerJson is null');
+          showDialog({
+            type: 'error',
+            title: 'Invalid Pack',
+            message: `${packFileName} is invalid and cannot be installed.`,
+          });
           return;
         }
 
@@ -193,6 +196,14 @@ export function installPackDialog() {
       }
     })
     .catch((err: any) => {
-      dialog.showErrorBox('Error', getErrorMsg(err));
+      console.error(
+        'installPackDialog(): An unknown error occurred:',
+        getErrorMsg(err)
+      );
+      showDialog({
+        type: 'error',
+        title: 'Error Installing Pack',
+        message: `An unexpected error occurred. ${getErrorMsg(err)}`,
+      });
     });
 }

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -1,3 +1,6 @@
+import { dialog, MessageBoxOptions, MessageBoxReturnValue } from 'electron';
+import { getMainWindow } from './window.js';
+
 export function isDev(): boolean {
   return process.env.NODE_ENV === 'development';
 }
@@ -21,4 +24,16 @@ export function isWayland() {
     process.env.XDG_SESSION_TYPE === 'wayland' ||
     Boolean(process.env.WAYLAND_DISPLAY)
   );
+}
+
+export async function showDialog(
+  options: MessageBoxOptions
+): Promise<MessageBoxReturnValue | null> {
+  const mainWindow = getMainWindow();
+
+  if (mainWindow) {
+    return dialog.showMessageBox(mainWindow, options);
+  }
+
+  return null;
 }


### PR DESCRIPTION
For whatever reason, `dialog.showErrorBox()` is not designed to be modal. This can cause a crash if the user interacts with the main window while an error box is open.

This is fixed by using `dialog.showMessageBox()` with `type: 'error'`, as this dialog is designed to display as a modal dialog.

This fixes #83.