### PR TITLE
Replace the default About panel with a custom About modal dialog

### DIFF
--- a/src/electron/constants.ts
+++ b/src/electron/constants.ts
@@ -1,6 +1,8 @@
 import { app } from 'electron';
 import path from 'path';
 
+export const COPYRIGHT_YEAR = '2026';
+
 // Paths
 export const CONFIG_PATH = path.join(app.getPath('userData'), 'config.json');
 

--- a/src/electron/dialogs.ts
+++ b/src/electron/dialogs.ts
@@ -8,7 +8,7 @@ export async function showAboutPanel() {
   const xdgSessionType = process.env.XDG_SESSION_TYPE;
   const details = [
     `Version: ${app.getVersion()}`,
-    `OS: ${os.version} ${os.arch} ${process.getSystemVersion()}`,
+    `OS: ${os.type} ${os.arch} ${process.getSystemVersion()}`,
     ...(xdgSessionType
       ? [`XDG Session Type: ${process.env.XDG_SESSION_TYPE}`]
       : []),

--- a/src/electron/dialogs.ts
+++ b/src/electron/dialogs.ts
@@ -1,0 +1,42 @@
+import { app } from 'electron';
+import os from 'os';
+import { COPYRIGHT_YEAR } from './constants.js';
+import { getAboutPanelIconPath } from './pathResolver.js';
+import { showDialog } from './util.js';
+
+export function showAboutPanel() {
+  const xdgSessionType = process.env.XDG_SESSION_TYPE;
+  const details = [
+    `Version: ${app.getVersion()}`,
+    `OS: ${os.version} ${os.arch} ${process.getSystemVersion()}`,
+    ...(xdgSessionType
+      ? [`XDG Session Type: ${process.env.XDG_SESSION_TYPE}`]
+      : []),
+    `Electron: ${process.versions.electron}`,
+    `Node.js: ${process.versions.node}`,
+    `Chromium: ${process.versions.chrome}`,
+    `V8: ${process.versions.v8}`,
+  ];
+
+  showDialog({
+    type: 'info',
+    icon: getAboutPanelIconPath(),
+    title: `About ${app.getName()}`,
+    message: app.getName(),
+    detail: details.join('\n'),
+  });
+}
+
+export function showLicense() {
+  const details = [
+    `Copyright (c) ${COPYRIGHT_YEAR} BashPrime`,
+    'This software is free for personal and commercial use under the MIT License.',
+  ];
+
+  showDialog({
+    type: 'info',
+    title: 'License',
+    message: 'License',
+    detail: details.join('\n'),
+  });
+}

--- a/src/electron/dialogs.ts
+++ b/src/electron/dialogs.ts
@@ -1,10 +1,10 @@
-import { app } from 'electron';
+import { app, clipboard } from 'electron';
 import os from 'os';
 import { COPYRIGHT_YEAR } from './constants.js';
 import { getAboutPanelIconPath } from './pathResolver.js';
 import { showDialog } from './util.js';
 
-export function showAboutPanel() {
+export async function showAboutPanel() {
   const xdgSessionType = process.env.XDG_SESSION_TYPE;
   const details = [
     `Version: ${app.getVersion()}`,
@@ -17,14 +17,24 @@ export function showAboutPanel() {
     `Chromium: ${process.versions.chrome}`,
     `V8: ${process.versions.v8}`,
   ];
+  const detailsStr = details.join('\n');
 
-  showDialog({
+  const res = await showDialog({
     type: 'info',
     icon: getAboutPanelIconPath(),
     title: `About ${app.getName()}`,
     message: app.getName(),
-    detail: details.join('\n'),
+    detail: detailsStr,
+    buttons: ['Copy', 'OK'],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
   });
+
+  // User clicked 'Copy'
+  if (res?.response === 0) {
+    clipboard.writeText(detailsStr);
+  }
 }
 
 export function showLicense() {

--- a/src/electron/dialogs.ts
+++ b/src/electron/dialogs.ts
@@ -10,7 +10,7 @@ export async function showAboutPanel() {
     `Version: ${app.getVersion()}`,
     `OS: ${os.type} ${os.arch} ${process.getSystemVersion()}`,
     ...(xdgSessionType
-      ? [`XDG Session Type: ${process.env.XDG_SESSION_TYPE}`]
+      ? [`Display Server: ${process.env.XDG_SESSION_TYPE}`]
       : []),
     `Electron: ${process.versions.electron}`,
     `Node.js: ${process.versions.node}`,

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -2,7 +2,6 @@ import { app } from 'electron';
 import path from 'path';
 import { handleCreateUserDataDirs, readConfigFile } from './config.js';
 import { runIpcHandlers } from './ipc.js';
-import { getAboutPanelIconPath } from './pathResolver.js';
 import { isDev, isWayland } from './util.js';
 import { createMainWindow } from './window.js';
 
@@ -11,15 +10,6 @@ if (isWayland()) {
 }
 
 app.on('ready', () => {
-  app.setAboutPanelOptions({
-    applicationName: 'BashPrime Hint Tracker',
-    applicationVersion: `v${app.getVersion()}`,
-    website: 'https://github.com/bashprime/prime-hint-tracker',
-    copyright:
-      `Copyright (c) 2026 BashPrime` +
-      '\n\nThis software is free for personal and commercial use under the MIT License.',
-    iconPath: getAboutPanelIconPath(),
-  });
   const config = readConfigFile();
   const mainWindow = createMainWindow(config);
 

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -11,6 +11,7 @@ import {
   TRACKER_HOME_MENU_TEXT,
   USER_DATA_DIR,
 } from './constants.js';
+import { showAboutPanel } from './dialogs.js';
 import {
   exportTrackerState,
   importTrackerState,
@@ -149,7 +150,10 @@ const template: MenuItemConstructorOptions[] = [
           { role: 'zoomOut' },
         ],
       },
-  { label: 'Help', submenu: [{ label: 'About', role: 'about' }] },
+  {
+    label: 'Help',
+    submenu: [{ label: 'About', click: () => showAboutPanel() }],
+  },
   { label: `Version ${app.getVersion()}` },
 ];
 


### PR DESCRIPTION
- The About panel is now a modal `dialog.showMessageBox` instance
- Technical details have been added to the about panel, including the OS version and package versions for things like Electron, Node, and Chromium.
- These details can be copied to the clipboard as part of diagnosing and solving future issues.