### PR TITLE
Install pack renderer button

### DIFF
--- a/src/electron/constants.ts
+++ b/src/electron/constants.ts
@@ -26,6 +26,7 @@ export const IPC_IDS = {
   exportTrackerState: 'export-tracker-state',
   exportTrackerStateResponse: 'export-tracker-state-response',
   importTrackerState: 'import-tracker-state',
+  installPack: 'install-pack',
 };
 
 // Tracker

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -14,6 +14,7 @@ import {
   getAllPacksInDir,
   getBasicPack,
   getPackDetails,
+  installPackDialog,
 } from './packs.js';
 import { getErrorMsg, showDialog } from './util.js';
 import { getMainWindow, resetWindowSize } from './window.js';
@@ -121,6 +122,10 @@ export function runIpcHandlers() {
       resetTrackerMenuItem.enabled = enabled;
     }
   });
+
+  ipcMain.handle(IPC_IDS.installPack, () => {
+    installPackDialog();
+  })
 }
 
 // these calls originate from ipcMain.

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -18,6 +18,7 @@ electron.contextBridge.exposeInMainWorld('electronApi', {
 
     return () => ipcRenderer.removeListener('reset-tracker', subscription);
   },
+  installPack: () => ipcRenderer.invoke('install-pack'),
   resetSize: (callback: () => void) => {
     const subscription = (_event: any) => callback();
     ipcRenderer.on('reset-size', subscription);

--- a/src/ui/ipc.ts
+++ b/src/ui/ipc.ts
@@ -57,3 +57,7 @@ export async function fetchTrackerAutosave(packId: string) {
 export function setExportTrackerStateMenuItem(enabled: boolean) {
   window.electronApi.setTrackerMenuItems(enabled);
 }
+
+export function installPack() {
+  window.electronApi.installPack();
+}

--- a/src/ui/routes/index.tsx
+++ b/src/ui/routes/index.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/')({
 // oxlint-disable-next-line react/only-export-components
 function Index() {
   return (
-    <div data-name="route-index">
+    <div className="h-full" data-name="route-index">
       <PackSelection />
     </div>
   );

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { packsState } from '@/states/App.states';
 import { Link } from '@tanstack/react-router';
 import { useAtomValue } from 'jotai';
-import { User } from 'lucide-react';
+import { Plus, User } from 'lucide-react';
 import { ReactNode } from 'react';
 
 type InstallPackButtonProps = {
@@ -21,7 +21,7 @@ function InstallPackButton({ children, className }: InstallPackButtonProps) {
         'hover:brightness-125',
         'bg-bashprime-red hover:bg-bashprime-red',
         'dark:bg-bashprime-yellow dark:hover:bg-bashprime-yellow',
-        'cursor-pointer p-10 text-2xl sm:w-100',
+        'cursor-pointer',
         className
       )}
     >
@@ -44,7 +44,9 @@ export function PackSelection() {
         data-name="pack-selection-no-packs"
       >
         <p className="p-2 text-4xl font-bold uppercase">No Packs Installed!</p>
-        <InstallPackButton className="text-4xl p-12">Install Pack</InstallPackButton>
+        <InstallPackButton className="p-10 p-12 text-2xl text-4xl sm:w-100">
+          Install Pack
+        </InstallPackButton>
       </div>
     );
   }
@@ -60,11 +62,17 @@ export function PackSelection() {
         className="flex w-full flex-col items-center gap-1"
         data-name="selection-header"
       >
-        <p className="p-2 text-center text-4xl font-bold uppercase">
-          Select a Pack
-        </p>
-        <div className="bg-bashprime-yellow h-1.5 w-3/5 min-w-72" />
-        <div className="bg-bashprime-red h-1.5 w-3/5 min-w-72" />
+        <div
+          className="my-4 flex w-auto flex-row items-center justify-center gap-6"
+          data-name="header-text-and-button"
+        >
+          <p className="text-4xl font-bold uppercase">Select a Pack </p>
+          <InstallPackButton className="px-4 py-5">
+            <Plus className="size-8" />
+          </InstallPackButton>
+        </div>
+        <div className="bg-bashprime-yellow h-1.5 w-4/5" />
+        <div className="bg-bashprime-red h-1.5 w-4/5" />
       </div>
       <div className={cn('flex flex-wrap justify-center gap-6 p-4')}>
         {sortedPacks.map((pack, idx) => (

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -50,22 +50,22 @@ export function PackSelection() {
             to="/packs/$packId"
             params={{ packId: pack.id }}
             key={idx}
-            className="group mb-6 flex w-max break-inside-avoid flex-col gap-1"
+            className="group flex w-max break-inside-avoid flex-col gap-1"
           >
             <GameCover
               name={pack.cover?.name ?? ''}
               image={pack.cover ?? undefined}
               className={cn(
-                'h-[280px] w-auto',
+                'h-56 sm:h-88 object-contain object-left',
                 'group-hover:outline-bashprime-red group-hover:outline group-hover:brightness-125',
                 'dark:group-hover:outline-bashprime-yellow',
                 'shadow-foreground group-hover:shadow-md/25'
               )}
             />
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <p
                 className={cn(
-                  'text-lg font-semibold',
+                  'text-md font-semibold sm:text-lg',
                   'group-hover:text-bashprime-red',
                   'dark:group-hover:text-bashprime-yellow',
                   'text-shadow-muted-foreground group-hover:text-shadow-sm/10'
@@ -90,8 +90,8 @@ export function PackSelection() {
                 'dark:group-hover:text-bashprime-yellow dark:group-hover:brightness-80'
               )}
             >
-              <User size={16} />
-              <p className="text-md">{pack.author}</p>
+              <User className="size-4 sm:size-5" />
+              <p className="sm:text-md text-sm">{pack.author}</p>
             </div>
           </Link>
         ))}

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -1,9 +1,34 @@
 import { GameCover } from '@/components/game-cover';
+import { Button } from '@/components/ui/button';
+import { installPack } from '@/ipc';
 import { cn } from '@/lib/utils';
 import { packsState } from '@/states/App.states';
 import { Link } from '@tanstack/react-router';
 import { useAtomValue } from 'jotai';
 import { User } from 'lucide-react';
+import { ReactNode } from 'react';
+
+type InstallPackButtonProps = {
+  children: ReactNode;
+  className?: string;
+};
+function InstallPackButton({ children, className }: InstallPackButtonProps) {
+  return (
+    <Button
+      variant="default"
+      onClick={installPack}
+      className={cn(
+        'hover:brightness-125',
+        'bg-bashprime-red hover:bg-bashprime-red',
+        'dark:bg-bashprime-yellow dark:hover:bg-bashprime-yellow',
+        'cursor-pointer p-10 text-2xl sm:w-100',
+        className
+      )}
+    >
+      {children}
+    </Button>
+  );
+}
 
 export function PackSelection() {
   // !STATE
@@ -11,18 +36,15 @@ export function PackSelection() {
 
   if (!(packs && packs.length)) {
     return (
-      <div data-name="pack-selection-no-packs">
-        <div className="flex flex-col items-center">
-          <p className="p-2 text-center text-4xl font-bold uppercase">
-            No Packs Installed!
-          </p>
-          <p className="text-center text-2xl">
-            Packs can be installed from the menu by going to:
-          </p>
-          <p className="font-mono text-2xl font-bold">
-            {'File > Install Pack'}
-          </p>
-        </div>
+      <div
+        className={cn(
+          'flex flex-col items-center justify-center gap-2',
+          'h-full'
+        )}
+        data-name="pack-selection-no-packs"
+      >
+        <p className="p-2 text-4xl font-bold uppercase">No Packs Installed!</p>
+        <InstallPackButton className="text-4xl p-12">Install Pack</InstallPackButton>
       </div>
     );
   }
@@ -56,7 +78,7 @@ export function PackSelection() {
               name={pack.cover?.name ?? ''}
               image={pack.cover ?? undefined}
               className={cn(
-                'h-56 sm:h-88 object-contain object-left',
+                'h-56 object-contain object-left sm:h-88',
                 'group-hover:outline-bashprime-red group-hover:outline group-hover:brightness-125',
                 'dark:group-hover:outline-bashprime-yellow',
                 'shadow-foreground group-hover:shadow-md/25'

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -44,7 +44,7 @@ export function PackSelection() {
         <div className="bg-bashprime-yellow h-1.5 w-3/5 min-w-72" />
         <div className="bg-bashprime-red h-1.5 w-3/5 min-w-72" />
       </div>
-      <div className={cn('flex flex-wrap gap-6 p-4')}>
+      <div className={cn('flex flex-wrap justify-center gap-6 p-4')}>
         {sortedPacks.map((pack, idx) => (
           <Link
             to="/packs/$packId"

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,6 +5,7 @@ interface Window {
     fetchImage: (packId: string, imgPath: string) => Promise<object>;
     autosaveTrackerState: (state: object, packId: string) => void;
     loadTrackerAutosave: (packId: string) => Promise<object | null>;
+    installPack: () => void;
     // ipcMain functions
     resetTracker: (callback: () => void) => () => void;
     resetSize: (callback: () => void) => () => void;


### PR DESCRIPTION
- Added "Install Pack" button that opens the installer dialog to both the "No Packs Installed" screen and the pack selection component (#102)
- "No Packs Installed" screen is now displayed on the very center of the window (#76)
- Packs in pack selection are now center aligned (#107)
- Packs now scale smaller if the window is smaller than the `sm` responsive breakpoint width