### PR TITLE
Unhinted Items: Move "Add Hint" above the hints array

### DIFF
--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -7,7 +7,10 @@ import { showDevtoolsState } from '@/states/App.states';
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
-import ScrollSizeDevtools, { JotaiDevTools, RouterDevTools } from './-components/dev-tools';
+import ScrollSizeDevtools, {
+  JotaiDevTools,
+  RouterDevTools,
+} from './-components/dev-tools';
 
 // oxlint-disable-next-line react/only-export-components
 function RootLayout() {

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -126,21 +126,25 @@ export function UnhintedItems({ unhinted }: Props) {
       {unhinted.header && (
         <Header color={unhinted.color}>{unhinted.header}</Header>
       )}
-      <div className="flex min-h-0 flex-col gap-2" data-name="uh-body">
+      <div className="flex min-h-0 flex-col" data-name="uh-body">
+        <Button
+          onClick={addHint}
+          className={cn(
+            'hover:brightness-125',
+            'bg-bashprime-red hover:bg-bashprime-red',
+            'dark:bg-bashprime-yellow dark:hover:bg-bashprime-yellow',
+            'w-full cursor-pointer place-self-center rounded-none',
+            'text-lg font-bold uppercase'
+          )}
+          data-name="add-hint-button"
+        >
+          <Plus className="size-6" /> Add New Hint
+        </Button>
         <div className="overflow-y-auto" data-name="uh-hints">
           {parsedHints.map((hint) => (
             <Hint hint={hint} key={hint.code} onDelete={deleteHint} />
           ))}
         </div>
-        <Button
-          onClick={addHint}
-          variant="outline"
-          className={cn(
-            'dark:border-input mb-2 cursor-pointer place-self-center border-zinc-500'
-          )}
-        >
-          <Plus /> Add new hint
-        </Button>
       </div>
     </div>
   );

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -128,17 +128,15 @@ export function UnhintedItems({ unhinted }: Props) {
       )}
       <div className="flex min-h-0 flex-col" data-name="uh-body">
         <Button
+          variant="secondary"
           onClick={addHint}
           className={cn(
-            'hover:brightness-125',
-            'bg-bashprime-red hover:bg-bashprime-red',
-            'dark:bg-bashprime-yellow dark:hover:bg-bashprime-yellow',
             'w-full cursor-pointer place-self-center rounded-none',
             'text-lg font-bold uppercase'
           )}
           data-name="add-hint-button"
         >
-          <Plus className="size-6" /> Add New Hint
+          <Plus className="size-6" /> Add New
         </Button>
         <div className="overflow-y-auto" data-name="uh-hints">
           {parsedHints.map((hint) => (


### PR DESCRIPTION
This places the add button above the hints array and styles it to be flush with the hints.

Completes #111.