### PR TITLE
Light theme fixes

### DIFF
--- a/src/ui/components/loading-spinner.tsx
+++ b/src/ui/components/loading-spinner.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export function LoadingSpinner({ text }: Props) {
   return (
-    <div className="flex h-full justify-center" data-name="loading-spinner">
+    <div className="flex h-full justify-center bg-zinc-50 dark:bg-background" data-name="loading-spinner">
       <div className="flex flex-col items-center justify-center">
         <Spinner className="size-32" />
         <p className={cn('text-4xl')}>{text ? text : 'Loading...'}</p>

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -76,7 +76,7 @@ export function LayoutHint({ hint }: Props) {
     <div
       tabIndex={0}
       className={cn(
-        'bg-zinc-200 dark:bg-zinc-800',
+        'bg-zinc-100 dark:bg-zinc-800',
         'flex flex-auto flex-col px-1.5 py-1',
         'border border-zinc-300 dark:border-zinc-900',
         checked && 'bg-green-300/90 dark:bg-green-900/90'
@@ -111,7 +111,7 @@ export function LayoutHint({ hint }: Props) {
             style={{ color: !checked ? hint.color : '' }}
             className={cn(
               'text-sm font-bold uppercase select-none',
-              hint.color && !checked && 'brightness-75 dark:brightness-100',
+              hint.color && !checked && 'brightness-67 dark:brightness-100',
               checked && 'text-green-800 dark:text-green-400'
             )}
           >

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -40,7 +40,7 @@ export function PackSelection() {
       <div
         className={cn(
           'flex flex-col items-center justify-center gap-2',
-          'h-full'
+          'h-full bg-zinc-50'
         )}
         data-name="pack-selection-no-packs"
       >
@@ -56,7 +56,10 @@ export function PackSelection() {
 
   return (
     <div
-      className="flex flex-col items-center select-none"
+      className={cn(
+        'flex flex-col items-center select-none',
+        'dark:bg-background h-full bg-zinc-50'
+      )}
       data-name="pack-selection"
     >
       <div

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -40,7 +40,7 @@ export function PackSelection() {
       <div
         className={cn(
           'flex flex-col items-center justify-center gap-2',
-          'h-full bg-zinc-50'
+          'h-full bg-zinc-50 dark:bg-background'
         )}
         data-name="pack-selection-no-packs"
       >

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -34,7 +34,7 @@ function Hint({ hint, onDelete }: HintProps) {
   return (
     <div
       className={cn(
-        'bg-zinc-200 dark:bg-zinc-800',
+        'bg-zinc-100 dark:bg-zinc-800',
         'flex flex-auto flex-col px-1.5 py-1',
         'border border-zinc-300 dark:border-zinc-900',
         checked && 'bg-green-300/90 dark:bg-green-900/90'


### PR DESCRIPTION
General light theme tweaks to make the app appear less grey and have more background/foreground color contrast.

- Hints and unhinted items now use `bg-zinc-100` backgrounds.
- Pack selection and loading spinner now uses `bg-zinc-50` background.

Fixes #78.