### PR TITLE
Make sure pack name is parsed when autosaving

### DIFF
--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -63,6 +63,7 @@ export function runIpcHandlers() {
           const trackerState = TrackerSaveStateSchema.parse({
             pack: {
               id: pack.id,
+              name: pack.name,
               version: pack.version,
             },
             state,


### PR DESCRIPTION
Autosaving was broken because the pack name wasn't getting parsed.