### PR TITLE
Limit the number of unhinted items

### DIFF
--- a/src/ui/components/loading-spinner.tsx
+++ b/src/ui/components/loading-spinner.tsx
@@ -7,7 +7,10 @@ type Props = {
 
 export function LoadingSpinner({ text }: Props) {
   return (
-    <div className="flex h-full justify-center bg-zinc-50 dark:bg-background" data-name="loading-spinner">
+    <div
+      className="dark:bg-background flex h-full justify-center bg-zinc-50"
+      data-name="loading-spinner"
+    >
       <div className="flex flex-col items-center justify-center">
         <Spinner className="size-32" />
         <p className={cn('text-4xl')}>{text ? text : 'Loading...'}</p>

--- a/src/ui/helpers/layoutStateBuilder.ts
+++ b/src/ui/helpers/layoutStateBuilder.ts
@@ -156,7 +156,8 @@ export function buildLayoutState(
 }
 
 export function buildUnhintedState(
-  saveState?: TrackerSaveState
+  saveState?: TrackerSaveState,
+  limit?: number
 ): UnhintedItemHint[] {
   const unhinted = saveState
     ? Object.entries(saveState.state).filter(([key]) =>
@@ -164,7 +165,7 @@ export function buildUnhintedState(
       )
     : [];
 
-  return unhinted.map(([key, val]) =>
+  const parsed = unhinted.map(([key, val]) =>
     UnhintedItemHintSchema.parse({
       code: key,
       item: atom(val.item ?? ''),
@@ -172,4 +173,10 @@ export function buildUnhintedState(
       checked: atom(val.checked ?? false),
     })
   );
+
+  if (limit) {
+    return parsed.slice(0, limit);
+  }
+
+  return parsed;
 }

--- a/src/ui/routes/packs/$packId.tsx
+++ b/src/ui/routes/packs/$packId.tsx
@@ -66,9 +66,12 @@ export const Route = createFileRoute('/packs/$packId')({
     }
 
     // Build the tracker state
-    const unhintedLimit = store.get(unhintedItemsLimitAtom)
+    const unhintedLimit = store.get(unhintedItemsLimitAtom);
     store.set(layoutState, buildLayoutState(pack.layout, trackerState));
-    store.set(unhintedHintsState, buildUnhintedState(trackerState, unhintedLimit));
+    store.set(
+      unhintedHintsState,
+      buildUnhintedState(trackerState, unhintedLimit)
+    );
     setExportTrackerStateMenuItem(true);
   },
   onLeave: async () => {

--- a/src/ui/routes/packs/$packId.tsx
+++ b/src/ui/routes/packs/$packId.tsx
@@ -18,6 +18,7 @@ import {
   packsState,
   trackerStateToLoad,
   unhintedHintsState,
+  unhintedItemsLimitAtom,
 } from '@/states/App.states';
 import { LayoutParser } from '@/views/layout/parser';
 import { createFileRoute, redirect } from '@tanstack/react-router';
@@ -65,8 +66,9 @@ export const Route = createFileRoute('/packs/$packId')({
     }
 
     // Build the tracker state
+    const unhintedLimit = store.get(unhintedItemsLimitAtom)
     store.set(layoutState, buildLayoutState(pack.layout, trackerState));
-    store.set(unhintedHintsState, buildUnhintedState(trackerState));
+    store.set(unhintedHintsState, buildUnhintedState(trackerState, unhintedLimit));
     setExportTrackerStateMenuItem(true);
   },
   onLeave: async () => {

--- a/src/ui/states/App.states.ts
+++ b/src/ui/states/App.states.ts
@@ -21,6 +21,9 @@ export const unhintedHintsState = atom<UnhintedItemHint[]>([]);
 export const importTrackerState = atom<TrackerSaveState | null>(null);
 export const trackerStateToLoad = atom<'autosave' | 'import'>('autosave');
 export const showDevtoolsState = atom<boolean>(isDev());
+// !WHY it's an arbitrary limit, but most players likely won't be using that many unhinted items
+// also, putting it in an atom makes it easy to configure later :)
+export const unhintedItemsLimitAtom = atom<number>(50);
 
 export const trackerHintsAtom = atom((get) => {
   // !STATE

--- a/src/ui/views/layout/pack-selection.tsx
+++ b/src/ui/views/layout/pack-selection.tsx
@@ -40,7 +40,7 @@ export function PackSelection() {
       <div
         className={cn(
           'flex flex-col items-center justify-center gap-2',
-          'h-full bg-zinc-50 dark:bg-background'
+          'dark:bg-background h-full bg-zinc-50'
         )}
         data-name="pack-selection-no-packs"
       >

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -3,12 +3,15 @@ import { Button } from '@/components/ui/button';
 import { useComboboxOptionsBuilder } from '@/hooks/useComboboxOptionsBuilder';
 import { useRightClick } from '@/hooks/useRightClick';
 import { cn } from '@/lib/utils';
-import { unhintedHintsState } from '@/states/App.states';
+import {
+  unhintedHintsState,
+  unhintedItemsLimitAtom,
+} from '@/states/App.states';
 import {
   LayoutStateUnhintedItems,
   UnhintedItemHint,
 } from '@/types/state.types';
-import { atom, useAtom } from 'jotai';
+import { atom, useAtom, useAtomValue } from 'jotai';
 import { Plus, X } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { Header } from './header';
@@ -88,8 +91,7 @@ type Props = {
 export function UnhintedItems({ unhinted }: Props) {
   // !STATE
   const [hints, setHints] = useAtom(unhintedHintsState);
-  // !WHY it's an arbitrary limit, but most players likely won't be using that many unhinted items
-  const lengthLimit = 50;
+  const lengthLimit = useAtomValue(unhintedItemsLimitAtom);
 
   const parsedHints = hints.map((h) => ({
     ...h,

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -88,6 +88,8 @@ type Props = {
 export function UnhintedItems({ unhinted }: Props) {
   // !STATE
   const [hints, setHints] = useAtom(unhintedHintsState);
+  // !WHY it's an arbitrary limit, but most players likely won't be using that many unhinted items
+  const lengthLimit = 50;
 
   const parsedHints = hints.map((h) => ({
     ...h,
@@ -96,17 +98,20 @@ export function UnhintedItems({ unhinted }: Props) {
 
   // !FUNCTION
   function addHint() {
-    setHints([
-      ...hints,
-      {
-        name: '',
-        code: `unhinted-${uuidv4()}`,
-        type: 'hint',
-        item: atom(''),
-        location: atom(''),
-        checked: atom(false),
-      } satisfies UnhintedItemHint,
-    ]);
+    // only add another hint if below the limit
+    if (hints.length < lengthLimit) {
+      setHints([
+        ...hints,
+        {
+          name: '',
+          code: `unhinted-${uuidv4()}`,
+          type: 'hint',
+          item: atom(''),
+          location: atom(''),
+          checked: atom(false),
+        } satisfies UnhintedItemHint,
+      ]);
+    }
   }
 
   function deleteHint(code: string) {
@@ -134,6 +139,7 @@ export function UnhintedItems({ unhinted }: Props) {
             'w-full cursor-pointer place-self-center rounded-none',
             'text-lg font-bold uppercase'
           )}
+          disabled={hints.length >= lengthLimit}
           data-name="add-hint-button"
         >
           <Plus className="size-6" /> Add New


### PR DESCRIPTION
- Added a jotai atom that determines how many unhinted items the player can add/generate
  - arbitrarily 100 as I don't think players will be making that many unhinted items during a playthrough
- Add validation step so that the app doesn't build more than {LIMIT} hints from json state