### PR TITLE
Refactor hint checkbox display, interaction, and state

### DIFF
--- a/src/electron/constants.ts
+++ b/src/electron/constants.ts
@@ -28,6 +28,7 @@ export const IPC_IDS = {
   importTrackerState: 'import-tracker-state',
   installPack: 'install-pack',
   setAccessibleCheckboxes: 'set-accessible-checkboxes',
+  rendererLoaded: 'renderer-loaded',
 };
 
 // Tracker

--- a/src/electron/constants.ts
+++ b/src/electron/constants.ts
@@ -27,6 +27,7 @@ export const IPC_IDS = {
   exportTrackerStateResponse: 'export-tracker-state-response',
   importTrackerState: 'import-tracker-state',
   installPack: 'install-pack',
+  setAccessibleCheckboxes: 'set-accessible-checkboxes',
 };
 
 // Tracker
@@ -46,6 +47,7 @@ export const MENU_IDS = {
   toggles: {
     alwaysOnTop: 'alwaysOnTop',
     resetSizeOnPackOpen: 'resetSizeOnPackOpen',
+    accessibleCheckboxes: 'accessibleCheckboxes',
   },
   theme: {
     system: 'system',

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -22,10 +22,12 @@ import { getMainWindow, resetWindowSize } from './window.js';
 export function runIpcHandlers() {
   // set some state when React app has loaded
   ipcMain.handle(IPC_IDS.rendererLoaded, () => {
-    const checkboxes = menu.getMenuItemById(MENU_IDS.toggles.accessibleCheckboxes);
-    setAccessibleCheckboxes(checkboxes?.checked ?? false)
+    const checkboxes = menu.getMenuItemById(
+      MENU_IDS.toggles.accessibleCheckboxes
+    );
+    setAccessibleCheckboxes(checkboxes?.checked ?? false);
   });
-  
+
   // get all basic packs data
   ipcMain.handle(IPC_IDS.fetchPacks, () => {
     return getAllPacksInDir();

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -20,6 +20,12 @@ import { getErrorMsg, showDialog } from './util.js';
 import { getMainWindow, resetWindowSize } from './window.js';
 
 export function runIpcHandlers() {
+  // set some state when React app has loaded
+  ipcMain.handle(IPC_IDS.rendererLoaded, () => {
+    const checkboxes = menu.getMenuItemById(MENU_IDS.toggles.accessibleCheckboxes);
+    setAccessibleCheckboxes(checkboxes?.checked ?? false)
+  });
+  
   // get all basic packs data
   ipcMain.handle(IPC_IDS.fetchPacks, () => {
     return getAllPacksInDir();

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -302,3 +302,8 @@ export function importTrackerState() {
       });
     });
 }
+
+export function setAccessibleCheckboxes(enabled: boolean) {
+  const mainWindow = getMainWindow();
+  mainWindow?.webContents.send(IPC_IDS.setAccessibleCheckboxes, enabled)
+}

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -305,5 +305,5 @@ export function importTrackerState() {
 
 export function setAccessibleCheckboxes(enabled: boolean) {
   const mainWindow = getMainWindow();
-  mainWindow?.webContents.send(IPC_IDS.setAccessibleCheckboxes, enabled)
+  mainWindow?.webContents.send(IPC_IDS.setAccessibleCheckboxes, enabled);
 }

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -119,7 +119,7 @@ const template: MenuItemConstructorOptions[] = [
         label: 'Accessible Checkboxes',
         type: 'checkbox',
         checked: false,
-        click: (item) => setAccessibleCheckboxes(item.checked)
+        click: (item) => setAccessibleCheckboxes(item.checked),
       },
       {
         label: 'Theme',

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -17,6 +17,7 @@ import {
   importTrackerState,
   resetSize,
   resetTracker,
+  setAccessibleCheckboxes,
   trackerHome,
 } from './ipc.js';
 import { installPackDialog } from './packs.js';
@@ -112,6 +113,13 @@ const template: MenuItemConstructorOptions[] = [
         label: "Use Pack's Default Window Size on Load",
         type: 'checkbox',
         checked: false,
+      },
+      {
+        id: MENU_IDS.toggles.accessibleCheckboxes,
+        label: 'Accessible Checkboxes',
+        type: 'checkbox',
+        checked: false,
+        click: (item) => setAccessibleCheckboxes(item.checked)
       },
       {
         label: 'Theme',

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -51,4 +51,11 @@ electron.contextBridge.exposeInMainWorld('electronApi', {
   },
   exportTrackerStateResponse: (state: object, packId: string | null) =>
     ipcRenderer.invoke('export-tracker-state-response', state, packId),
+  setAccessibleCheckboxes: (callback: (enabled: boolean) => void) => {
+    const subscription = (_event: any, enabled: boolean) => callback(enabled);
+    ipcRenderer.on('set-accessible-checkboxes', subscription);
+
+    return () =>
+      ipcRenderer.removeListener('set-accessible-checkboxes', subscription);
+  },
 });

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -3,6 +3,7 @@ import { ipcRenderer } from 'electron';
 const electron = require('electron');
 
 electron.contextBridge.exposeInMainWorld('electronApi', {
+  rendererLoaded: () => ipcRenderer.invoke('renderer-loaded'),
   fetchPacks: () => ipcRenderer.invoke('fetch-packs'),
   fetchPackDetails: (fileName: string) =>
     ipcRenderer.invoke('fetch-pack-details', fileName),

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -8,7 +8,6 @@ import {
   DEFAULT_WINDOW_SIZE,
   MENU_IDS,
 } from './constants.js';
-import { setAccessibleCheckboxes } from './ipc.js';
 import { menu } from './menu.js';
 import { getBasicPack } from './packs.js';
 import { getIconPath, getPreloadPath } from './pathResolver.js';
@@ -34,9 +33,9 @@ export function createMainWindow(config: ConfigType | null) {
 
   if (config) {
     setInitialTheme(config.theme);
-    setResetPackSize(config.resetSizeOnPackOpen);
-    mainWindow.setAlwaysOnTop(config.alwaysOnTop);
-    setAccessibleCheckboxes(config.accessibleCheckboxes);
+    setInitialResetPackSize(config.resetSizeOnPackOpen);
+    setInitialAlwaysOnTop(config.alwaysOnTop);
+    setInitialAccessibleCheckboxes(config.accessibleCheckboxes);
   }
 
   Menu.setApplicationMenu(menu);
@@ -57,6 +56,18 @@ export function closeMainWindow() {
   mainWindow?.close();
 }
 
+function setInitialAlwaysOnTop(checked: boolean) {
+  const mainWindow = getMainWindow();
+  const alwaysOnTop = menu.getMenuItemById(
+    MENU_IDS.toggles.alwaysOnTop
+  );
+
+  if (alwaysOnTop) {
+    mainWindow?.setAlwaysOnTop(checked);
+    alwaysOnTop.checked = checked;
+  }
+}
+
 function setInitialTheme(theme: ThemeType) {
   nativeTheme.themeSource = theme;
   const menuThemeRadioItem = menu.getMenuItemById(MENU_IDS.theme[theme]);
@@ -65,13 +76,23 @@ function setInitialTheme(theme: ThemeType) {
   }
 }
 
-function setResetPackSize(checked: boolean) {
+function setInitialResetPackSize(checked: boolean) {
   const resetPackSize = menu.getMenuItemById(
     MENU_IDS.toggles.resetSizeOnPackOpen
   );
 
   if (resetPackSize) {
     resetPackSize.checked = checked;
+  }
+}
+
+function setInitialAccessibleCheckboxes(checked: boolean) {
+  const accessibleCheckboxes = menu.getMenuItemById(
+    MENU_IDS.toggles.accessibleCheckboxes
+  );
+
+  if (accessibleCheckboxes) {
+    accessibleCheckboxes.checked = checked;
   }
 }
 

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -58,9 +58,7 @@ export function closeMainWindow() {
 
 function setInitialAlwaysOnTop(checked: boolean) {
   const mainWindow = getMainWindow();
-  const alwaysOnTop = menu.getMenuItemById(
-    MENU_IDS.toggles.alwaysOnTop
-  );
+  const alwaysOnTop = menu.getMenuItemById(MENU_IDS.toggles.alwaysOnTop);
 
   if (alwaysOnTop) {
     mainWindow?.setAlwaysOnTop(checked);

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_WINDOW_SIZE,
   MENU_IDS,
 } from './constants.js';
+import { setAccessibleCheckboxes } from './ipc.js';
 import { menu } from './menu.js';
 import { getBasicPack } from './packs.js';
 import { getIconPath, getPreloadPath } from './pathResolver.js';
@@ -34,6 +35,8 @@ export function createMainWindow(config: ConfigType | null) {
   if (config) {
     setInitialTheme(config.theme);
     setResetPackSize(config.resetSizeOnPackOpen);
+    mainWindow.setAlwaysOnTop(config.alwaysOnTop);
+    setAccessibleCheckboxes(config.accessibleCheckboxes);
   }
 
   Menu.setApplicationMenu(menu);
@@ -77,8 +80,12 @@ function handleSaveConfig() {
     const parsed = ConfigSchema.parse({
       theme: nativeTheme.themeSource,
       window: mainWindow?.getBounds() ?? DEFAULT_WINDOW_BOUNDS,
+      alwaysOnTop: mainWindow?.isAlwaysOnTop() ?? false,
       resetSizeOnPackOpen:
         menu.getMenuItemById(MENU_IDS.toggles.resetSizeOnPackOpen)?.checked ??
+        false,
+      accessibleCheckboxes:
+        menu.getMenuItemById(MENU_IDS.toggles.accessibleCheckboxes)?.checked ??
         false,
     });
 

--- a/src/shared/types/config.types.ts
+++ b/src/shared/types/config.types.ts
@@ -5,7 +5,9 @@ import { SemVerSchema } from './base.types.js';
 export const ConfigSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']),
   window: z.custom<Rectangle>(),
+  alwaysOnTop: z.boolean(),
   resetSizeOnPackOpen: z.boolean(),
+  accessibleCheckboxes: z.boolean(),
 });
 export type ConfigType = z.infer<typeof ConfigSchema>;
 

--- a/src/ui/components/ui/checkbox.tsx
+++ b/src/ui/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon } from "lucide-react"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/ui/components/ui/checkbox.tsx
+++ b/src/ui/components/ui/checkbox.tsx
@@ -1,14 +1,14 @@
-import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 
-import { cn } from "@/lib/utils"
-import { CheckIcon } from "lucide-react"
+import { cn } from '@/lib/utils';
+import { CheckIcon } from 'lucide-react';
 
 function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        'peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3',
         className
       )}
       {...props}
@@ -17,11 +17,10 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
-        <CheckIcon
-        />
+        <CheckIcon />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-  )
+  );
 }
 
-export { Checkbox }
+export { Checkbox };

--- a/src/ui/components/ui/input.tsx
+++ b/src/ui/components/ui/input.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm',
+        'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 text-sm',
         className
       )}
       {...props}

--- a/src/ui/components/ui/input.tsx
+++ b/src/ui/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 text-sm',
+        'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border bg-transparent px-2.5 py-1 text-base text-sm shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3',
         className
       )}
       {...props}

--- a/src/ui/hooks/useSetAccessibleCheckboxes.ts
+++ b/src/ui/hooks/useSetAccessibleCheckboxes.ts
@@ -1,10 +1,10 @@
-import { accessibleCheckboxesState } from "@/states/App.states";
-import { useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { accessibleCheckboxesState } from '@/states/App.states';
+import { useSetAtom } from 'jotai';
+import { useEffect } from 'react';
 
 export function useSetAccessibleCheckboxes() {
   // !STATE
-  const setAccessibleCheckboxes = useSetAtom(accessibleCheckboxesState)
+  const setAccessibleCheckboxes = useSetAtom(accessibleCheckboxesState);
 
   useEffect(() => {
     // !IPC

--- a/src/ui/hooks/useSetAccessibleCheckboxes.ts
+++ b/src/ui/hooks/useSetAccessibleCheckboxes.ts
@@ -1,0 +1,20 @@
+import { accessibleCheckboxesState } from "@/states/App.states";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+export function useSetAccessibleCheckboxes() {
+  // !STATE
+  const setAccessibleCheckboxes = useSetAtom(accessibleCheckboxesState)
+
+  useEffect(() => {
+    // !IPC
+    const cleanup = window.electronApi.setAccessibleCheckboxes((enabled) => {
+      setAccessibleCheckboxes(enabled);
+    });
+
+    // Execute both cleanups when the component unmounts
+    return () => {
+      cleanup();
+    };
+  }, [setAccessibleCheckboxes]);
+}

--- a/src/ui/ipc.ts
+++ b/src/ui/ipc.ts
@@ -7,6 +7,10 @@ import { BasicPack, PackDetails } from '../shared/types/pack.types';
 import { buildComboboxOptionsDatabase } from './helpers/comboboxOptions';
 import { activePackState, packsState } from './states/App.states';
 
+export function rendererLoaded() {
+  window.electronApi.rendererLoaded();
+}
+
 export async function fetchPacks() {
   const data = (await window.electronApi.fetchPacks()) as BasicPack[];
   try {

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -2,6 +2,7 @@ import { isDev } from '@/helpers/utils';
 import { useAutosaveTracker } from '@/hooks/useAutosaveTracker';
 import { useImportExportTrackerState } from '@/hooks/useImportExportTrackerState';
 import { useResetSize } from '@/hooks/useResetSize';
+import { useSetAccessibleCheckboxes } from '@/hooks/useSetAccessibleCheckboxes';
 import { useThemeChanger } from '@/hooks/useThemeChanger';
 import { useTrackerHome } from '@/hooks/useTrackerHome';
 import { showDevtoolsState } from '@/states/App.states';
@@ -24,6 +25,7 @@ function RootLayout() {
   useImportExportTrackerState();
   useResetSize();
   useThemeChanger();
+  useSetAccessibleCheckboxes();
 
   useEffect(() => {
     function toggleDevtools(event: KeyboardEvent) {

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -5,6 +5,7 @@ import { useResetSize } from '@/hooks/useResetSize';
 import { useSetAccessibleCheckboxes } from '@/hooks/useSetAccessibleCheckboxes';
 import { useThemeChanger } from '@/hooks/useThemeChanger';
 import { useTrackerHome } from '@/hooks/useTrackerHome';
+import { rendererLoaded } from '@/ipc';
 import { showDevtoolsState } from '@/states/App.states';
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { useAtom } from 'jotai';
@@ -27,6 +28,7 @@ function RootLayout() {
   useThemeChanger();
   useSetAccessibleCheckboxes();
 
+  // Handle toggle dev tools
   useEffect(() => {
     function toggleDevtools(event: KeyboardEvent) {
       if (event.ctrlKey && event.key === 'k') {
@@ -43,7 +45,10 @@ function RootLayout() {
     };
   });
 
-  // !FUNCTION
+  // Trigger renderer loaded on root mount
+  useEffect(() => {
+    rendererLoaded();
+  }, []);
 
   return (
     <>

--- a/src/ui/states/App.states.ts
+++ b/src/ui/states/App.states.ts
@@ -24,6 +24,7 @@ export const showDevtoolsState = atom<boolean>(isDev());
 // !WHY it's an arbitrary limit, but most players likely won't be using that many unhinted items
 // also, putting it in an atom makes it easy to configure later :)
 export const unhintedItemsLimitAtom = atom<number>(50);
+export const accessibleCheckboxesState = atom<boolean>(false);
 
 export const trackerHintsAtom = atom((get) => {
   // !STATE

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -100,9 +100,23 @@ export function LayoutHint({ hint }: Props) {
           />
         </div>
       )}
+      {hint.item && (
+        <AtomCombobox
+          atom={hint.item}
+          placeholder={'Item'}
+          options={itemOptions}
+        />
+      )}
+      {hint.location && (
+        <AtomCombobox
+          atom={hint.location}
+          placeholder={'Location'}
+          options={locationOptions}
+        />
+      )}
       <div
         className={cn(
-          'flex flex-row',
+          'order-first flex flex-row',
           hint.name && 'justify-between',
           !hint.name && 'h-0 justify-end'
         )}
@@ -121,20 +135,6 @@ export function LayoutHint({ hint }: Props) {
         )}
         <HintChecked checkedAtom={hint.checked} />
       </div>
-      {hint.item && (
-        <AtomCombobox
-          atom={hint.item}
-          placeholder={'Item'}
-          options={itemOptions}
-        />
-      )}
-      {hint.location && (
-        <AtomCombobox
-          atom={hint.location}
-          placeholder={'Location'}
-          options={locationOptions}
-        />
-      )}
     </div>
   );
 }

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/states/App.states';
 import { HintWithState } from '@/types/state.types';
 import { PrimitiveAtom, useAtom, useAtomValue } from 'jotai';
-import { Check } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Image } from '../../../shared/types/image.types';
 
@@ -24,21 +23,14 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
   const accessibleCheckboxes = useAtomValue(accessibleCheckboxesState);
   const [checked, setChecked] = useAtom(checkedAtom);
 
-  if (accessibleCheckboxes) {
-    return (
-      <Checkbox
-        checked={checked}
-        onCheckedChange={setChecked}
-        className={cn('order-3 cursor-pointer', 'mr-1', className)}
-      />
-    );
-  }
   return (
-    <Check
+    <Checkbox
+      checked={checked}
+      onCheckedChange={setChecked}
+      disabled={!accessibleCheckboxes}
       className={cn(
-        'text-green-800 dark:text-green-300',
-        'mx-1 my-0.5 size-4',
-        !checked && 'opacity-0',
+        !accessibleCheckboxes && !checked && 'hidden',
+        accessibleCheckboxes && 'cursor-pointer',
         className
       )}
     />
@@ -116,9 +108,10 @@ export function LayoutHint({ hint }: Props) {
       )}
       <div
         className={cn(
-          'order-[-9998] flex flex-row',
+          'relative order-[-9998] flex flex-row',
           hint.name && 'justify-between',
-          !hint.name && 'h-0 justify-end'
+          !hint.name && 'h-0 justify-end',
+          'relative'
         )}
       >
         {hint.name && (
@@ -133,7 +126,10 @@ export function LayoutHint({ hint }: Props) {
             {hint.name}
           </p>
         )}
-        <HintChecked checkedAtom={hint.checked} />
+        <HintChecked
+          checkedAtom={hint.checked}
+          className="absolute top-0 right-0 mx-1 my-0.5 p-2"
+        />
       </div>
     </div>
   );

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -35,6 +35,8 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
         'data-checked:bg-zinc-200 data-checked:text-green-950',
         'data-checked:dark:border-zinc-600',
         !accessibleCheckboxes && !checked && 'invisible',
+        !accessibleCheckboxes &&
+          'data-checked:text-green:800 data-checked:border-none data-checked:bg-transparent data-checked:dark:bg-transparent data-checked:dark:text-green-300',
         accessibleCheckboxes && 'cursor-pointer',
         className
       )}
@@ -116,7 +118,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         className={cn(
           'order-[-9998]',
           'flex flex-row',
-          hint.name && 'gap-2 items-start justify-between',
+          hint.name && 'items-start justify-between gap-2',
           !hint.name && 'h-0 justify-end'
         )}
       >
@@ -134,7 +136,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         )}
         <div
           className={cn(
-            'z-10 mr-0.75', // prevents weird scrolling behavior
+            'z-10 mr-1.25 lg:mr-0.75', // prevents weird scrolling behavior
             'flex flex-row items-center gap-1',
             !hint.name && 'mt-2.5'
           )}
@@ -142,7 +144,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         >
           <HintChecked
             checkedAtom={hint.checked}
-            className="size-5 select-none z-11"
+            className="z-11 size-5 select-none"
           />
           {onDelete && (
             <Button
@@ -150,8 +152,14 @@ export function LayoutHint({ hint, onDelete }: Props) {
               size="icon"
               variant="ghost"
               onDoubleClick={() => onDelete(hint.code)}
+              onKeyDown={(e) => {
+                // Allow for keyboard deletions
+                if (e.key === 'Enter' || e.key === ' ' || e.key === 'Space') {
+                  onDelete(hint.code);
+                }
+              }}
               className={cn(
-                'cursor-pointer select-none z-12',
+                'z-12 cursor-pointer select-none',
                 'text-red-600 dark:text-red-500',
                 'hover:bg-red-300 dark:hover:bg-red-400 dark:hover:text-black',
                 checked && 'text-red-700 dark:text-red-600'

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -135,12 +135,15 @@ export function LayoutHint({ hint, onDelete }: Props) {
         <div
           className={cn(
             'z-10 mr-0.75', // prevents weird scrolling behavior
-            'flex-right flex items-center gap-2',
+            'flex flex-row items-center gap-2',
             !hint.name && 'mt-4'
           )}
           data-name="hint-buttons"
         >
-          <HintChecked checkedAtom={hint.checked} className="size-6 select-none" />
+          <HintChecked
+            checkedAtom={hint.checked}
+            className="size-6 select-none"
+          />
           {onDelete && (
             <Button
               tabIndex={0}

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -1,21 +1,38 @@
 import { AtomCombobox } from '@/components/atom-combobox';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useComboboxOptionsBuilder } from '@/hooks/useComboboxOptionsBuilder';
 import { useRightClick } from '@/hooks/useRightClick';
 import { fetchImage } from '@/ipc';
 import { cn } from '@/lib/utils';
-import { activePackState } from '@/states/App.states';
+import {
+  accessibleCheckboxesState,
+  activePackState,
+} from '@/states/App.states';
 import { HintWithState } from '@/types/state.types';
-import { useAtom, useAtomValue } from 'jotai';
+import { PrimitiveAtom, useAtom, useAtomValue } from 'jotai';
 import { Check } from 'lucide-react';
-import { KeyboardEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Image } from '../../../shared/types/image.types';
 
 type HintCheckedProps = {
-  checked: boolean;
+  checkedAtom: PrimitiveAtom<boolean>;
   className?: string;
 };
 
-export function HintChecked({ checked, className }: HintCheckedProps) {
+export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
+  // !STATE
+  const accessibleCheckboxes = useAtomValue(accessibleCheckboxesState);
+  const [checked, setChecked] = useAtom(checkedAtom);
+
+  if (accessibleCheckboxes) {
+    return (
+      <Checkbox
+        checked={checked}
+        onCheckedChange={setChecked}
+        className={cn('order-3 cursor-pointer', 'mr-1', className)}
+      />
+    );
+  }
   return (
     <Check
       className={cn(
@@ -54,27 +71,12 @@ export function LayoutHint({ hint }: Props) {
     fetchHintImage();
   }, [pack, hint]);
 
-  // !FUNCTION
-  function handleSpacebarKeyDown(event: KeyboardEvent<HTMLElement>) {
-    const target = event.target as HTMLElement;
-
-    if (target.tagName === 'INPUT') {
-      return;
-    }
-
-    if (event.code === 'Space' || event.key === ' ') {
-      event.preventDefault();
-      setChecked(!checked);
-    }
-  }
-
   // !OPTIONS
   const itemOptions = buildOptions(hint.comboboxOptions?.item ?? []);
   const locationOptions = buildOptions(hint.comboboxOptions?.location ?? []);
 
   return (
     <div
-      tabIndex={0}
       className={cn(
         'bg-zinc-100 dark:bg-zinc-800',
         'flex flex-auto flex-col px-1.5 py-1',
@@ -87,7 +89,6 @@ export function LayoutHint({ hint }: Props) {
           : undefined,
       }}
       onMouseDown={handleRightClick}
-      onKeyDown={handleSpacebarKeyDown}
       data-name="layout-hint"
     >
       {image && (
@@ -118,7 +119,7 @@ export function LayoutHint({ hint }: Props) {
             {hint.name}
           </p>
         )}
-        <HintChecked checked={checked} />
+        <HintChecked checkedAtom={hint.checked} />
       </div>
       {hint.item && (
         <AtomCombobox

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -116,7 +116,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         className={cn(
           'order-[-9998]',
           'flex flex-row',
-          hint.name && 'justify-between',
+          hint.name && 'gap-2 items-start justify-between',
           !hint.name && 'h-0 justify-end'
         )}
       >
@@ -135,14 +135,14 @@ export function LayoutHint({ hint, onDelete }: Props) {
         <div
           className={cn(
             'z-10 mr-0.75', // prevents weird scrolling behavior
-            'flex flex-row items-center gap-2',
-            !hint.name && 'mt-4'
+            'flex flex-row items-center gap-1',
+            !hint.name && 'mt-2.5'
           )}
           data-name="hint-buttons"
         >
           <HintChecked
             checkedAtom={hint.checked}
-            className="size-6 select-none"
+            className="size-5 select-none z-11"
           />
           {onDelete && (
             <Button
@@ -151,7 +151,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
               variant="ghost"
               onDoubleClick={() => onDelete(hint.code)}
               className={cn(
-                'cursor-pointer select-none',
+                'cursor-pointer select-none z-12',
                 'text-red-600 dark:text-red-500',
                 'hover:bg-red-300 dark:hover:bg-red-400 dark:hover:text-black',
                 checked && 'text-red-700 dark:text-red-600'

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -1,4 +1,5 @@
 import { AtomCombobox } from '@/components/atom-combobox';
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useComboboxOptionsBuilder } from '@/hooks/useComboboxOptionsBuilder';
 import { useRightClick } from '@/hooks/useRightClick';
@@ -10,6 +11,7 @@ import {
 } from '@/states/App.states';
 import { HintWithState } from '@/types/state.types';
 import { PrimitiveAtom, useAtom, useAtomValue } from 'jotai';
+import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Image } from '../../../shared/types/image.types';
 
@@ -39,9 +41,10 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
 
 type Props = {
   hint: HintWithState;
+  onDelete?: (code: string) => void;
 };
 
-export function LayoutHint({ hint }: Props) {
+export function LayoutHint({ hint, onDelete }: Props) {
   // !STATE
   const pack = useAtomValue(activePackState);
   const [checked, setChecked] = useAtom(hint.checked);
@@ -106,7 +109,7 @@ export function LayoutHint({ hint }: Props) {
           />
         </div>
       )}
-      <div className={cn('relative order-[-9998]')}>
+      <div className={cn('order-[-9998]', 'flex flex-row justify-between')}>
         {hint.name && (
           <p
             style={{ color: !checked ? hint.color : '' }}
@@ -119,10 +122,27 @@ export function LayoutHint({ hint }: Props) {
             {hint.name}
           </p>
         )}
-        <HintChecked
-          checkedAtom={hint.checked}
-          className="absolute top-0 right-0 mx-1 my-0.5 p-2"
-        />
+        <div
+          className={cn('flex flex-row items-center gap-2')}
+          data-name="hint-buttons"
+        >
+          <HintChecked checkedAtom={hint.checked} className="size-6" />
+          {onDelete && (
+            <Button
+              tabIndex={0}
+              variant="ghost"
+              onDoubleClick={() => onDelete(hint.code)}
+              className={cn(
+                'size-7 cursor-pointer',
+                'text-red-600 dark:text-red-500',
+                'hover:bg-red-300 dark:hover:bg-red-400 dark:hover:text-black',
+                hint.checked && 'text-red-500'
+              )}
+            >
+              <X className="size-7" />
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -31,6 +31,8 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
       onCheckedChange={setChecked}
       disabled={!accessibleCheckboxes}
       className={cn(
+        'border-zinc-400 dark:border-zinc-600',
+        'data-checked:bg-zinc-200 data-checked:text-green-800',
         !accessibleCheckboxes && !checked && 'invisible',
         accessibleCheckboxes && 'cursor-pointer',
         className
@@ -131,7 +133,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         )}
         <div
           className={cn(
-            'flex flex-row items-center gap-2 mx-1',
+            'mx-1 flex flex-row items-center gap-2',
             !hint.name && 'mt-4'
           )}
           data-name="hint-buttons"

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -106,14 +106,7 @@ export function LayoutHint({ hint }: Props) {
           />
         </div>
       )}
-      <div
-        className={cn(
-          'relative order-[-9998] flex flex-row',
-          hint.name && 'justify-between',
-          !hint.name && 'h-0 justify-end',
-          'relative'
-        )}
-      >
+      <div className={cn('relative order-[-9998]')}>
         {hint.name && (
           <p
             style={{ color: !checked ? hint.color : '' }}

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -91,15 +91,6 @@ export function LayoutHint({ hint }: Props) {
       onMouseDown={handleRightClick}
       data-name="layout-hint"
     >
-      {image && (
-        <div className="mb-1 w-24 select-none" data-name="hint-img">
-          <img
-            src={`data:image/${image.type};base64,${image.data}`}
-            title={hint.name}
-            alt={`Image for ${hint.name}`}
-          />
-        </div>
-      )}
       {hint.item && (
         <AtomCombobox
           atom={hint.item}
@@ -114,9 +105,18 @@ export function LayoutHint({ hint }: Props) {
           options={locationOptions}
         />
       )}
+      {image && (
+        <div className="order-first mb-1 w-24 select-none" data-name="hint-img">
+          <img
+            src={`data:image/${image.type};base64,${image.data}`}
+            title={hint.name}
+            alt={`Image for ${hint.name}`}
+          />
+        </div>
+      )}
       <div
         className={cn(
-          'order-first flex flex-row',
+          'order-[-9998] flex flex-row',
           hint.name && 'justify-between',
           !hint.name && 'h-0 justify-end'
         )}

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -32,7 +32,8 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
       disabled={!accessibleCheckboxes}
       className={cn(
         'border-zinc-400 dark:border-zinc-600',
-        'data-checked:bg-zinc-200 data-checked:text-green-800',
+        'data-checked:bg-zinc-200 data-checked:text-green-950',
+        'data-checked:dark:border-zinc-600',
         !accessibleCheckboxes && !checked && 'invisible',
         accessibleCheckboxes && 'cursor-pointer',
         className
@@ -106,8 +107,8 @@ export function LayoutHint({ hint, onDelete }: Props) {
         <div className="order-first mb-1 w-24 select-none" data-name="hint-img">
           <img
             src={`data:image/${image.type};base64,${image.data}`}
-            title={hint.name}
-            alt={`Image for ${hint.name}`}
+            title={hint.code}
+            alt={`Image for ${hint.code}`}
           />
         </div>
       )}
@@ -133,25 +134,27 @@ export function LayoutHint({ hint, onDelete }: Props) {
         )}
         <div
           className={cn(
-            'mx-1 flex flex-row items-center gap-2',
+            'z-10 mr-0.75', // prevents weird scrolling behavior
+            'flex-right flex items-center gap-2',
             !hint.name && 'mt-4'
           )}
           data-name="hint-buttons"
         >
-          <HintChecked checkedAtom={hint.checked} className="size-6" />
+          <HintChecked checkedAtom={hint.checked} className="size-6 select-none" />
           {onDelete && (
             <Button
               tabIndex={0}
+              size="icon"
               variant="ghost"
               onDoubleClick={() => onDelete(hint.code)}
               className={cn(
-                'size-7 cursor-pointer',
+                'cursor-pointer select-none',
                 'text-red-600 dark:text-red-500',
                 'hover:bg-red-300 dark:hover:bg-red-400 dark:hover:text-black',
-                hint.checked && 'text-red-500'
+                checked && 'text-red-700 dark:text-red-600'
               )}
             >
-              <X className="size-7" />
+              <X className="size-6" />
             </Button>
           )}
         </div>

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -31,7 +31,7 @@ export function HintChecked({ checkedAtom, className }: HintCheckedProps) {
       onCheckedChange={setChecked}
       disabled={!accessibleCheckboxes}
       className={cn(
-        !accessibleCheckboxes && !checked && 'hidden',
+        !accessibleCheckboxes && !checked && 'invisible',
         accessibleCheckboxes && 'cursor-pointer',
         className
       )}
@@ -109,7 +109,14 @@ export function LayoutHint({ hint, onDelete }: Props) {
           />
         </div>
       )}
-      <div className={cn('order-[-9998]', 'flex flex-row justify-between')}>
+      <div
+        className={cn(
+          'order-[-9998]',
+          'flex flex-row',
+          hint.name && 'justify-between',
+          !hint.name && 'h-0 justify-end'
+        )}
+      >
         {hint.name && (
           <p
             style={{ color: !checked ? hint.color : '' }}
@@ -123,7 +130,10 @@ export function LayoutHint({ hint, onDelete }: Props) {
           </p>
         )}
         <div
-          className={cn('flex flex-row items-center gap-2')}
+          className={cn(
+            'flex flex-row items-center gap-2 mx-1',
+            !hint.name && 'mt-4'
+          )}
           data-name="hint-buttons"
         >
           <HintChecked checkedAtom={hint.checked} className="size-6" />

--- a/src/ui/views/layout/parser.tsx
+++ b/src/ui/views/layout/parser.tsx
@@ -19,14 +19,11 @@ type Props = {
 export function LayoutParser({ elem }: Props) {
   return (
     <>
-      {elem.type === 'group' && (
-        <LayoutArray array={elem as LayoutStateArray} />
-      )}
+      {elem.type === 'hint' && <LayoutHint hint={elem as HintWithState} />}
       {elem.type === 'array' && (
         <LayoutArray array={elem as LayoutStateArray} />
       )}
       {elem.type === 'grid' && <LayoutGrid grid={elem as LayoutStateGrid} />}
-      {elem.type === 'hint' && <LayoutHint hint={elem as HintWithState} />}
       {elem.type === 'unhinted' && (
         <UnhintedItems unhinted={elem as LayoutStateUnhintedItems} />
       )}

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -47,7 +47,7 @@ function Hint({ hint, onDelete }: HintProps) {
     >
       <div className={cn('flex flex-row items-center justify-between')}>
         <div className="flex w-full flex-row gap-2">
-          <HintChecked checked={checked} />
+          <HintChecked checkedAtom={hint.checked} />
           <div className="flex-1" data-name="hints-container">
             {hint.item && (
               <AtomCombobox

--- a/src/ui/views/layout/unhinted-items.tsx
+++ b/src/ui/views/layout/unhinted-items.tsx
@@ -1,7 +1,4 @@
-import { AtomCombobox } from '@/components/atom-combobox';
 import { Button } from '@/components/ui/button';
-import { useComboboxOptionsBuilder } from '@/hooks/useComboboxOptionsBuilder';
-import { useRightClick } from '@/hooks/useRightClick';
 import { cn } from '@/lib/utils';
 import {
   unhintedHintsState,
@@ -12,77 +9,10 @@ import {
   UnhintedItemHint,
 } from '@/types/state.types';
 import { atom, useAtom, useAtomValue } from 'jotai';
-import { Plus, X } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { Header } from './header';
-import { HintChecked } from './hint';
-
-type HintProps = {
-  hint: UnhintedItemHint;
-  onDelete: (code: string) => void;
-};
-
-function Hint({ hint, onDelete }: HintProps) {
-  // !STATE
-  const [checked, setChecked] = useAtom(hint.checked);
-
-  // !HOOKS
-  const handleRightClick = useRightClick(() => setChecked(!checked));
-  const { buildOptions } = useComboboxOptionsBuilder();
-
-  // !OPTIONS
-  const itemOptions = buildOptions(hint.comboboxOptions?.item ?? []);
-  const locationOptions = buildOptions(hint.comboboxOptions?.location ?? []);
-
-  return (
-    <div
-      className={cn(
-        'bg-zinc-100 dark:bg-zinc-800',
-        'flex flex-auto flex-col px-1.5 py-1',
-        'border border-zinc-300 dark:border-zinc-900',
-        checked && 'bg-green-300/90 dark:bg-green-900/90'
-      )}
-      onMouseDown={handleRightClick}
-      data-name="layout-hint"
-    >
-      <div className={cn('flex flex-row items-center justify-between')}>
-        <div className="flex w-full flex-row gap-2">
-          <HintChecked checkedAtom={hint.checked} />
-          <div className="flex-1" data-name="hints-container">
-            {hint.item && (
-              <AtomCombobox
-                atom={hint.item}
-                placeholder="Item"
-                options={itemOptions}
-              />
-            )}
-            {hint.location && (
-              <AtomCombobox
-                atom={hint.location}
-                placeholder="Location"
-                options={locationOptions}
-              />
-            )}
-          </div>
-        </div>
-
-        <Button
-          tabIndex={0}
-          variant="ghost"
-          size="icon"
-          onClick={() => onDelete(hint.code)}
-          className={cn(
-            'cursor-pointer text-red-600 dark:text-red-500',
-            'hover:bg-red-300 dark:hover:bg-red-400 dark:hover:text-black',
-            checked && 'text-red-500'
-          )}
-        >
-          <X className="size-6" />
-        </Button>
-      </div>
-    </div>
-  );
-}
+import { LayoutHint } from './hint';
 
 type Props = {
   unhinted: LayoutStateUnhintedItems;
@@ -148,7 +78,7 @@ export function UnhintedItems({ unhinted }: Props) {
         </Button>
         <div className="overflow-y-auto" data-name="uh-hints">
           {parsedHints.map((hint) => (
-            <Hint hint={hint} key={hint.code} onDelete={deleteHint} />
+            <LayoutHint hint={hint} key={hint.code} onDelete={deleteHint} />
           ))}
         </div>
       </div>

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,6 +15,8 @@ interface Window {
     exportTrackerState: (callback: () => void) => () => void;
     importTrackerState: (callback: (state: object) => void) => () => void;
     exportTrackerStateResponse: (state: object, packId: string | null) => void;
-    setAccessibleCheckboxes: (callback: (enabled: boolean) => void) => () => void;
+    setAccessibleCheckboxes: (
+      callback: (enabled: boolean) => void
+    ) => () => void;
   };
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,6 @@
 interface Window {
   electronApi: {
+    rendererLoaded: () => void;
     fetchPacks: () => Promise<object[]>;
     fetchPackDetails: (packId: string) => Promise<object>;
     fetchImage: (packId: string, imgPath: string) => Promise<object>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,5 +15,6 @@ interface Window {
     exportTrackerState: (callback: () => void) => () => void;
     importTrackerState: (callback: (state: object) => void) => () => void;
     exportTrackerStateResponse: (state: object, packId: string | null) => void;
+    setAccessibleCheckboxes: (callback: (enabled: boolean) => void) => () => void;
   };
 }


### PR DESCRIPTION
- Added new toggle: "Accessible Checkboxes", which lets the user tab to and set the hint's `checked` state with just their keyboard.
- The checkbox display is now a `shadcn` checkbox with various styling and props set based on the above toggle.
- Unhinted Items; The hint panels are now the same as the rest of the hint panels on a given tracker.
  - As a side effect, the unhinted checkbox and delete buttons are now grouped together in the top-right part of the panel.
- Fixed configuration issue where `always on top` wasn't being saved or loaded.

This PR fixes #101.