### PR TITLE
Reset Size now sets the content size instead of the entire window

### DIFF
--- a/docs/Pack.md
+++ b/docs/Pack.md
@@ -30,8 +30,10 @@
   "layout": [
     "<array of JSON file path strings describing your layout data. See Layout for more info>"
   ],
-  "defaultWindowSize": {
-    // this sets the application window size when `File > Reset Size` is clicked.
+  "defaultSize": {
+    // Optional object. If the pack has a defined `defaultSize` object when `File > Reset Size` is clicked, the application will resize the client area (the main content, not including the menu bar and title area) to the given width and height.
+
+    // If `defaultSize` is undefined, the application will reset the client area to 800x600 pixels when `File > Reset Size` is clicked.
     "width": "<number, pixel width>",
     "height": "<number, pixel height>"
   }

--- a/docs/Pack.md
+++ b/docs/Pack.md
@@ -34,6 +34,8 @@
     // Optional object. If the pack has a defined `defaultSize` object when `File > Reset Size` is clicked, the application will resize the client area (the main content, not including the menu bar and title area) to the given width and height.
 
     // If `defaultSize` is undefined, the application will reset the client area to 800x600 pixels when `File > Reset Size` is clicked.
+
+    // I recommend running the hint tracker in a development environment. There are some dev tools that will display, including the active scroll width and scroll height of the client area which can help with getting a good default width and height for your pack.
     "width": "<number, pixel width>",
     "height": "<number, pixel height>"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "unpack:win": "pnpm dlx @electron/asar extract ./dist/win-unpacked/resources/app.asar ./dist/app-asar-unpacked",
     "unpack:mac": "pnpm dlx @electron/asar extract ./dist/mac-unpacked/resources/app.asar ./dist/app-asar-unpacked",
     "unpack:linux": "pnpm dlx @electron/asar extract ./dist/linux-unpacked/resources/app.asar ./dist/app-asar-unpacked",
-    "gen-third-party-licenses": "pnpm dlx generate-license-file --input ./package.json --output ./NOTICE"
+    "gen-third-party-licenses": "pnpm dlx generate-license-file --input ./package.json --output ./NOTICE",
+    "gen-pack-schema": "pnpm dlx bun ./src/scripts/gen-pack-schema.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/schema/pack/layout/hint.json
+++ b/schema/pack/layout/hint.json
@@ -4,8 +4,6 @@
   "properties": {
     "color": { "type": "string" },
     "borderColor": { "type": "string" },
-    "grow": { "type": "boolean" },
-    "gap": { "type": "number" },
     "comboboxOptions": {
       "type": "object",
       "properties": {

--- a/schema/pack/layout/unhinted-items.json
+++ b/schema/pack/layout/unhinted-items.json
@@ -5,7 +5,6 @@
     "header": { "type": "string" },
     "color": { "type": "string" },
     "borderColor": { "type": "string" },
-    "gap": { "type": "number" },
     "comboboxOptions": {
       "type": "object",
       "properties": {

--- a/schema/pack/tracker.json
+++ b/schema/pack/tracker.json
@@ -17,7 +17,7 @@
     "locations": { "type": "array", "items": { "type": "string" } },
     "features": { "type": "array", "items": { "type": "string" } },
     "layout": { "type": "array", "items": { "type": "string" } },
-    "defaultWindowSize": {
+    "defaultSize": {
       "type": "object",
       "properties": {
         "width": { "type": "number" },

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -124,8 +124,7 @@ function mainWindowHandlers(window: BrowserWindow) {
 
 export function resetWindowSize(packId: string | null) {
   const pack = packId ? getBasicPack(packId) : null;
-  const packWindowSize =
-    pack && pack.defaultSize ? pack.defaultSize : null;
-  const size = packWindowSize ?? DEFAULT_WINDOW_SIZE;
-  mainWindow?.setSize(size.width, size.height, true);
+  const size =
+    pack && pack.defaultSize ? pack.defaultSize : DEFAULT_WINDOW_SIZE;
+  mainWindow?.setContentSize(size.width, size.height, true);
 }

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -120,16 +120,12 @@ function mainWindowHandlers(window: BrowserWindow) {
   window.on('close', () => {
     handleSaveConfig();
   });
-
-  if (isDev()) {
-    window.on('resize', () => console.log('window size:', window.getSize()));
-  }
 }
 
 export function resetWindowSize(packId: string | null) {
   const pack = packId ? getBasicPack(packId) : null;
   const packWindowSize =
-    pack && pack.defaultWindowSize ? pack.defaultWindowSize : null;
+    pack && pack.defaultSize ? pack.defaultSize : null;
   const size = packWindowSize ?? DEFAULT_WINDOW_SIZE;
   mainWindow?.setSize(size.width, size.height, true);
 }

--- a/src/shared/types/pack.types.ts
+++ b/src/shared/types/pack.types.ts
@@ -16,7 +16,7 @@ export const PackTrackerJsonSchema = z.object({
   locations: z.array(z.string()),
   features: z.array(z.string()),
   layout: z.array(z.string()),
-  defaultWindowSize: z
+  defaultSize: z
     .object({
       width: z.number(),
       height: z.number(),

--- a/src/ui/views/layout/hint.tsx
+++ b/src/ui/views/layout/hint.tsx
@@ -136,7 +136,7 @@ export function LayoutHint({ hint, onDelete }: Props) {
         )}
         <div
           className={cn(
-            'z-10 mr-1.25 lg:mr-0.75', // prevents weird scrolling behavior
+            'z-10 mr-[0.5rem]', // prevents weird scrolling behavior
             'flex flex-row items-center gap-1',
             !hint.name && 'mt-2.5'
           )}


### PR DESCRIPTION
- Pack `defaultWindowSize` is now `defaultSize` for semantics
- `window.setSize()` is now `window.contentSize()` for more accurate resizing across platforms
- Updated json schemas
- Updated pack documentation